### PR TITLE
Fix broken notification permission request (even better user retention)

### DIFF
--- a/src/awesome-memes.html
+++ b/src/awesome-memes.html
@@ -19,6 +19,9 @@
     body {
         background: linear-gradient(0deg, rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0.9)), url(https://media.discordapp.net/attachments/807809192537882647/887106375245778954/ezgif.com-gif-maker_81.gif);
     }
+    img {
+        max-width: 110%
+    }
 </style>
 <body>
 <div>
@@ -40,9 +43,9 @@
         <img src="https://c.tenor.com/P5B6lbpzwuQAAAAC/yh.gif" alt="britmoji"/>
         <img src="https://c.tenor.com/lyZh8_D5LcMAAAAC/the-peeper-peeper.gif" alt="britmoji"/>
         <img src="https://cdn.discordapp.com/attachments/806461073199988737/992818166696771684/vdsla7n14o891.png" alt="britmoji"/>
-        <img src="https://cdn.discordapp.com/attachments/750149098492919920/1034245369019781281/C7764CAC-CE25-4FDB-AEF6-B75FC295C282_1_102_o.jpeg" alt="britmoji"/>
-        <img src="https://cdn.discordapp.com/attachments/750149098492919920/1034245420647465060/6FEA2FEF-F266-4016-A2F2-7D60D1159A9C.jpeg" alt="britmoji"/>
         <img src="https://cdn.discordapp.com/attachments/750149098492919920/1034245594643959968/04CD11E6-A4F4-4805-8D17-B76FBC076C35_1_105_c.jpeg" alt="britmoji"/>
+        <img src="https://cdn.discordapp.com/attachments/750149098492919920/1034245420647465060/6FEA2FEF-F266-4016-A2F2-7D60D1159A9C.jpeg" alt="britmoji"/>
+        <img src="https://cdn.discordapp.com/attachments/750149098492919920/1034245369019781281/C7764CAC-CE25-4FDB-AEF6-B75FC295C282_1_102_o.jpeg" alt="britmoji"/>
         <img src="https://cdn.discordapp.com/attachments/806461073199988737/992818167103639613/53E01EB4-00AD-41C4-9059-D3A0C0101D71.png" alt="britmoji"/>
         <img src="https://cdn.discordapp.com/attachments/806461073199988737/992818167481118750/FNrbhdrXIAQVwls.jpg" alt="britmoji"/>
         <img src="https://cdn.discordapp.com/attachments/806461073199988737/992818362507853905/unknown.png" alt="britmoji"/>

--- a/src/awesome-memes.html
+++ b/src/awesome-memes.html
@@ -40,6 +40,9 @@
         <img src="https://c.tenor.com/P5B6lbpzwuQAAAAC/yh.gif" alt="britmoji"/>
         <img src="https://c.tenor.com/lyZh8_D5LcMAAAAC/the-peeper-peeper.gif" alt="britmoji"/>
         <img src="https://cdn.discordapp.com/attachments/806461073199988737/992818166696771684/vdsla7n14o891.png" alt="britmoji"/>
+        <img src="https://cdn.discordapp.com/attachments/750149098492919920/1034245369019781281/C7764CAC-CE25-4FDB-AEF6-B75FC295C282_1_102_o.jpeg" alt="britmoji"/>
+        <img src="https://cdn.discordapp.com/attachments/750149098492919920/1034245420647465060/6FEA2FEF-F266-4016-A2F2-7D60D1159A9C.jpeg" alt="britmoji"/>
+        <img src="https://cdn.discordapp.com/attachments/750149098492919920/1034245594643959968/04CD11E6-A4F4-4805-8D17-B76FBC076C35_1_105_c.jpeg" alt="britmoji"/>
         <img src="https://cdn.discordapp.com/attachments/806461073199988737/992818167103639613/53E01EB4-00AD-41C4-9059-D3A0C0101D71.png" alt="britmoji"/>
         <img src="https://cdn.discordapp.com/attachments/806461073199988737/992818167481118750/FNrbhdrXIAQVwls.jpg" alt="britmoji"/>
         <img src="https://cdn.discordapp.com/attachments/806461073199988737/992818362507853905/unknown.png" alt="britmoji"/>

--- a/src/index.html
+++ b/src/index.html
@@ -62,11 +62,24 @@
     <img src="https://stryvemarketing.com/wp-content/uploads/2016/04/flamingline.gif" alt="britmoji"/>
 
     <div>
+        <style>
+            #ferntag {
+                font-family: 'Comic Sans MS', 'Comic Sans', cursive;
+                background-image: url('https://www.cameronsworld.net/img/content/23/frame-26/bg.gif');
+                color: transparent;
+                background-clip: text;}
+            #ferntag:before {
+                color: red;
+                float: left;
+                margin: 0 0 0 -1em;
+                content: '\2022';}
+        </style>
         <h1 class="rainbow" id="notes">note s</h1>
         <ul>
             <li>hi vinny gaming (from tommy innit . com)</li>
             <li>cf pages bad (sopmetimes )</li>
             <li>hi dean (dean gaming ((from mine craftiest)) )</li>
+            <li id="ferntag">fern was here :></li>
         </ul>
     </div>
 

--- a/src/js/britmoji.js
+++ b/src/js/britmoji.js
@@ -31,7 +31,8 @@ const phrases = [
 	"@oomfies",
 	"hi oomfies",
 	createImage("https://media.discordapp.net/stickers/983690705727815731.webp?size=160"),
-	createImage("https://pbs.twimg.com/media/FcJpjQMWQAEI31Z?format=jpg&name=orig")
+	createImage("https://pbs.twimg.com/media/FcJpjQMWQAEI31Z?format=jpg&name=orig"),
+	"fern was here :>"
 ];
 
 let dvd = {
@@ -43,8 +44,6 @@ let dvd = {
 };
 
 (function main() {
-	Notification.requestPermission();
-
 	canvas = document.getElementById("tv-screen");
 	if (!canvas) return;
 
@@ -63,6 +62,7 @@ let dvd = {
 })();
 
 function onClick(e) {
+	if (Notification.permission === 'default') {Notification.requestPermission();}
 	const x = e.clientX;
 	const y = e.clientY;
 	clicks.push({

--- a/src/js/britmoji.js
+++ b/src/js/britmoji.js
@@ -32,7 +32,7 @@ const phrases = [
 	"hi oomfies",
 	createImage("https://media.discordapp.net/stickers/983690705727815731.webp?size=160"),
 	createImage("https://pbs.twimg.com/media/FcJpjQMWQAEI31Z?format=jpg&name=orig"),
-	"fern was here :>"
+	createImage("https://cdn.discordapp.com/attachments/750149098492919920/1034246067262328985/93B213DA-A819-4B2D-8EF5-03E887511BD6_1_102_o.jpeg?size=160") //My cat actual
 ];
 
 let dvd = {


### PR DESCRIPTION
Studies have shown that web push notifications have 30 times higher conversion when compared with mail. This is why I'm bringing an innovative change to Britmoji.org.

With over 4 billion websites in the world, we have to find new and cutting-edge ways to keep website traffic and patronage healthily growing. We need a solution that is easy for end users, does not disrupt core UX, and naturally promotes engagement, retention and connection. We can do all this along with optimise, visualise and steer user trajectories with one simple method.

**_Website Push Notifications_**. 
With notifications, we can effectively communicate with customers 24/7, increase conversion rates with a sense of urgency, drive organic traffic, even optimise the experience for seperate segments of customers based on historical data. We don't have to prompt users for personal information, which could be a hurdle for some, notifications are supported on almost all platforms, and the notification permission prompt is quick, simple, and probably almost quickly accepted by unthinking website visitors. Notifications are trust-worthy, attention grabbing and simple.

As for moving forward, techniques such as time-zone based notification timings, audience segmentation, and exclusive offers can be implemented to further the notification experience. I'm excited for what the future of Britmoji.org will bring.

Thanks for your time and I'll be happy to take any questions.

### Britmoji: Innovation, reimagination, penetration.